### PR TITLE
kick detection v1

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -32,13 +32,42 @@ function setup() {
     });
 }
 
+// Spectral flux kick detection for low frequencies
+let prevLowSpectrum = [];
+let spectralFluxBuffer = [];
+const fluxBufferSize = 20;
+let lastKickTime = 0;
+const kickCooldown = 200; // ms
+
 function kickDetect() {
-
-    let bassEnergy = fft.getEnergy('bass');
-
-    if (bassEnergy > bassThreshold) {
-        image(dawg, 0, 0, width, height);
+    let spectrum = fft.analyze();
+    
+    let lowBinStart = 1;
+    let lowBinEnd = 7;
+    
+    let currentLowSpectrum = spectrum.slice(lowBinStart, lowBinEnd + 1);
+    
+    if (prevLowSpectrum.length > 0) {
+        let flux = 0;
+        for (let i = 0; i < currentLowSpectrum.length; i++) {
+            let diff = currentLowSpectrum[i] - prevLowSpectrum[i];
+            if (diff > 0) flux += diff;
+        }
+        
+        spectralFluxBuffer.push(flux);
+        if (spectralFluxBuffer.length > fluxBufferSize) spectralFluxBuffer.shift();
+        
+        let meanFlux = spectralFluxBuffer.reduce((a, b) => a + b, 0) / spectralFluxBuffer.length;
+        let threshold = meanFlux * 1.8;
+        
+        let now = millis();
+        if (flux > threshold && flux > 15 && now - lastKickTime > kickCooldown) {
+            image(dawg, 0, 0, width, height);
+            lastKickTime = now;
+        }
     }
+    
+    prevLowSpectrum = [...currentLowSpectrum];
 }
 
 function draw() {


### PR DESCRIPTION

Summary:
added kick detection using spectral flux. takes moving average of last 20 flux measurements (which is a sum of the novelties), checks if this is greater than a threshold. also implemented a cooldown to distinguish between kicks and 808s

Test Plan:
website runs
