### PR TITLE
Feat/holographic gradient core

### DIFF
--- a/detections/themeEngine.js
+++ b/detections/themeEngine.js
@@ -10,8 +10,8 @@ const ARCHETYPES = [
         profile: { bassMean: 0.6, midMean: 0.3, trebleMean: 0.2, centroidMean: 0.15, kickRate: 0.15, bassVariance: 0.04 },
         theme: {
             baseColor: [10, 0, 20], peakColor: [180, 0, 255], bgColor: [0, 0, 0],
-            ballCount: 10, speed: 7, metaMode: true,
-            routing: { radius: {bass:1,mid:0,treble:0}, speed: {bass:0.3,mid:1,treble:0}, color: {bass:0,mid:0,treble:1} },
+            ballCount: 10, speed: 7, fringeIntensity: 0.5,
+            routing: { radius: {bass:1,mid:0,treble:0}, speed: {bass:0.3,mid:1,treble:0}, color: {bass:0,mid:0,treble:1}, gradient: {bass:1,mid:0,treble:0}, fringe: {bass:0,mid:0.3,treble:1} },
             kickSensitivity: 1.5
         }
     },
@@ -20,8 +20,8 @@ const ARCHETYPES = [
         profile: { bassMean: 0.4, midMean: 0.5, trebleMean: 0.5, centroidMean: 0.55, kickRate: 0.1, bassVariance: 0.02 },
         theme: {
             baseColor: [255, 200, 50], peakColor: [255, 100, 150], bgColor: [255, 250, 240],
-            ballCount: 7, speed: 5, metaMode: true,
-            routing: { radius: {bass:1,mid:0.3,treble:0}, speed: {bass:0,mid:1,treble:0.3}, color: {bass:0,mid:0.3,treble:1} },
+            ballCount: 7, speed: 5, fringeIntensity: 0.3,
+            routing: { radius: {bass:1,mid:0.3,treble:0}, speed: {bass:0,mid:1,treble:0.3}, color: {bass:0,mid:0.3,treble:1}, gradient: {bass:0.5,mid:0.5,treble:0}, fringe: {bass:0,mid:0.5,treble:1} },
             kickSensitivity: 1.8
         }
     },
@@ -30,8 +30,8 @@ const ARCHETYPES = [
         profile: { bassMean: 0.15, midMean: 0.25, trebleMean: 0.3, centroidMean: 0.6, kickRate: 0.01, bassVariance: 0.005 },
         theme: {
             baseColor: [180, 170, 150], peakColor: [220, 200, 160], bgColor: [240, 235, 220],
-            ballCount: 2, speed: 2, metaMode: false,
-            routing: { radius: {bass:0.5,mid:0.5,treble:0}, speed: {bass:0,mid:0.5,treble:0.5}, color: {bass:0,mid:1,treble:0.5} },
+            ballCount: 2, speed: 2, fringeIntensity: 0.1,
+            routing: { radius: {bass:0.5,mid:0.5,treble:0}, speed: {bass:0,mid:0.5,treble:0.5}, color: {bass:0,mid:1,treble:0.5}, gradient: {bass:0.3,mid:0.5,treble:0.3}, fringe: {bass:0,mid:0.5,treble:0.5} },
             kickSensitivity: 2.5
         }
     },
@@ -40,8 +40,8 @@ const ARCHETYPES = [
         profile: { bassMean: 0.7, midMean: 0.6, trebleMean: 0.5, centroidMean: 0.35, kickRate: 0.12, bassVariance: 0.06 },
         theme: {
             baseColor: [80, 0, 0], peakColor: [255, 255, 255], bgColor: [15, 0, 0],
-            ballCount: 14, speed: 8, metaMode: true,
-            routing: { radius: {bass:1,mid:0.5,treble:0}, speed: {bass:0.5,mid:1,treble:0.3}, color: {bass:0.3,mid:0,treble:1} },
+            ballCount: 14, speed: 8, fringeIntensity: 0.6,
+            routing: { radius: {bass:1,mid:0.5,treble:0}, speed: {bass:0.5,mid:1,treble:0.3}, color: {bass:0.3,mid:0,treble:1}, gradient: {bass:1,mid:0.3,treble:0}, fringe: {bass:0,mid:0,treble:1} },
             kickSensitivity: 1.3
         }
     },
@@ -50,8 +50,8 @@ const ARCHETYPES = [
         profile: { bassMean: 0.2, midMean: 0.2, trebleMean: 0.25, centroidMean: 0.45, kickRate: 0.005, bassVariance: 0.003 },
         theme: {
             baseColor: [0, 40, 60], peakColor: [0, 180, 200], bgColor: [5, 10, 25],
-            ballCount: 3, speed: 1, metaMode: true,
-            routing: { radius: {bass:0.5,mid:0.5,treble:0.3}, speed: {bass:0,mid:0.3,treble:0.5}, color: {bass:0.3,mid:0.5,treble:1} },
+            ballCount: 3, speed: 1, fringeIntensity: 0.3,
+            routing: { radius: {bass:0.5,mid:0.5,treble:0.3}, speed: {bass:0,mid:0.3,treble:0.5}, color: {bass:0.3,mid:0.5,treble:1}, gradient: {bass:0.3,mid:0.5,treble:0.5}, fringe: {bass:0,mid:0.5,treble:1} },
             kickSensitivity: 2.5
         }
     },
@@ -60,8 +60,8 @@ const ARCHETYPES = [
         profile: { bassMean: 0.35, midMean: 0.3, trebleMean: 0.2, centroidMean: 0.35, kickRate: 0.04, bassVariance: 0.01 },
         theme: {
             baseColor: [120, 80, 50], peakColor: [220, 180, 140], bgColor: [40, 25, 15],
-            ballCount: 5, speed: 3, metaMode: false,
-            routing: { radius: {bass:1,mid:0.3,treble:0}, speed: {bass:0,mid:1,treble:0}, color: {bass:0,mid:0.5,treble:1} },
+            ballCount: 5, speed: 3, fringeIntensity: 0.2,
+            routing: { radius: {bass:1,mid:0.3,treble:0}, speed: {bass:0,mid:1,treble:0}, color: {bass:0,mid:0.5,treble:1}, gradient: {bass:0.5,mid:0.5,treble:0}, fringe: {bass:0,mid:0.7,treble:0.5} },
             kickSensitivity: 2.0
         }
     },
@@ -70,8 +70,8 @@ const ARCHETYPES = [
         profile: { bassMean: 0.55, midMean: 0.35, trebleMean: 0.4, centroidMean: 0.4, kickRate: 0.18, bassVariance: 0.015 },
         theme: {
             baseColor: [0, 30, 10], peakColor: [0, 255, 180], bgColor: [0, 0, 0],
-            ballCount: 9, speed: 6, metaMode: true,
-            routing: { radius: {bass:1,mid:0,treble:0}, speed: {bass:0,mid:1,treble:0.5}, color: {bass:0,mid:0,treble:1} },
+            ballCount: 9, speed: 6, fringeIntensity: 0.5,
+            routing: { radius: {bass:1,mid:0,treble:0}, speed: {bass:0,mid:1,treble:0.5}, color: {bass:0,mid:0,treble:1}, gradient: {bass:1,mid:0,treble:0}, fringe: {bass:0,mid:0,treble:1} },
             kickSensitivity: 1.4
         }
     },
@@ -80,8 +80,8 @@ const ARCHETYPES = [
         profile: { bassMean: 0.3, midMean: 0.45, trebleMean: 0.35, centroidMean: 0.55, kickRate: 0.03, bassVariance: 0.02 },
         theme: {
             baseColor: [60, 40, 10], peakColor: [220, 180, 60], bgColor: [20, 15, 5],
-            ballCount: 4, speed: 3, metaMode: false,
-            routing: { radius: {bass:0.7,mid:0.5,treble:0}, speed: {bass:0,mid:1,treble:0.3}, color: {bass:0,mid:0.7,treble:1} },
+            ballCount: 4, speed: 3, fringeIntensity: 0.15,
+            routing: { radius: {bass:0.7,mid:0.5,treble:0}, speed: {bass:0,mid:1,treble:0.3}, color: {bass:0,mid:0.7,treble:1}, gradient: {bass:0.5,mid:0.5,treble:0}, fringe: {bass:0,mid:0.5,treble:0.5} },
             kickSensitivity: 2.2
         }
     }

--- a/detections/themeEngine.js
+++ b/detections/themeEngine.js
@@ -10,8 +10,7 @@ const ARCHETYPES = [
         profile: { bassMean: 0.6, midMean: 0.3, trebleMean: 0.2, centroidMean: 0.15, kickRate: 0.15, bassVariance: 0.04 },
         theme: {
             baseColor: [10, 0, 20], peakColor: [180, 0, 255], bgColor: [0, 0, 0],
-            ballCount: 10, speed: 7, fringeIntensity: 0.5,
-            routing: { radius: {bass:1,mid:0,treble:0}, speed: {bass:0.3,mid:1,treble:0}, color: {bass:0,mid:0,treble:1}, gradient: {bass:1,mid:0,treble:0}, fringe: {bass:0,mid:0.3,treble:1} },
+            ballCount: 10, speed: 7,            routing: { radius: {bass:1,mid:0,treble:0}, speed: {bass:0.3,mid:1,treble:0}, color: {bass:0,mid:0,treble:1}, gradient: {bass:1,mid:0,treble:0} },
             kickSensitivity: 1.5
         }
     },
@@ -20,8 +19,7 @@ const ARCHETYPES = [
         profile: { bassMean: 0.4, midMean: 0.5, trebleMean: 0.5, centroidMean: 0.55, kickRate: 0.1, bassVariance: 0.02 },
         theme: {
             baseColor: [255, 200, 50], peakColor: [255, 100, 150], bgColor: [255, 250, 240],
-            ballCount: 7, speed: 5, fringeIntensity: 0.3,
-            routing: { radius: {bass:1,mid:0.3,treble:0}, speed: {bass:0,mid:1,treble:0.3}, color: {bass:0,mid:0.3,treble:1}, gradient: {bass:0.5,mid:0.5,treble:0}, fringe: {bass:0,mid:0.5,treble:1} },
+            ballCount: 7, speed: 5,            routing: { radius: {bass:1,mid:0.3,treble:0}, speed: {bass:0,mid:1,treble:0.3}, color: {bass:0,mid:0.3,treble:1}, gradient: {bass:0.5,mid:0.5,treble:0} },
             kickSensitivity: 1.8
         }
     },
@@ -30,8 +28,7 @@ const ARCHETYPES = [
         profile: { bassMean: 0.15, midMean: 0.25, trebleMean: 0.3, centroidMean: 0.6, kickRate: 0.01, bassVariance: 0.005 },
         theme: {
             baseColor: [180, 170, 150], peakColor: [220, 200, 160], bgColor: [240, 235, 220],
-            ballCount: 2, speed: 2, fringeIntensity: 0.1,
-            routing: { radius: {bass:0.5,mid:0.5,treble:0}, speed: {bass:0,mid:0.5,treble:0.5}, color: {bass:0,mid:1,treble:0.5}, gradient: {bass:0.3,mid:0.5,treble:0.3}, fringe: {bass:0,mid:0.5,treble:0.5} },
+            ballCount: 2, speed: 2,            routing: { radius: {bass:0.5,mid:0.5,treble:0}, speed: {bass:0,mid:0.5,treble:0.5}, color: {bass:0,mid:1,treble:0.5}, gradient: {bass:0.3,mid:0.5,treble:0.3} },
             kickSensitivity: 2.5
         }
     },
@@ -40,8 +37,7 @@ const ARCHETYPES = [
         profile: { bassMean: 0.7, midMean: 0.6, trebleMean: 0.5, centroidMean: 0.35, kickRate: 0.12, bassVariance: 0.06 },
         theme: {
             baseColor: [80, 0, 0], peakColor: [255, 255, 255], bgColor: [15, 0, 0],
-            ballCount: 14, speed: 8, fringeIntensity: 0.6,
-            routing: { radius: {bass:1,mid:0.5,treble:0}, speed: {bass:0.5,mid:1,treble:0.3}, color: {bass:0.3,mid:0,treble:1}, gradient: {bass:1,mid:0.3,treble:0}, fringe: {bass:0,mid:0,treble:1} },
+            ballCount: 14, speed: 8,            routing: { radius: {bass:1,mid:0.5,treble:0}, speed: {bass:0.5,mid:1,treble:0.3}, color: {bass:0.3,mid:0,treble:1}, gradient: {bass:1,mid:0.3,treble:0} },
             kickSensitivity: 1.3
         }
     },
@@ -50,8 +46,7 @@ const ARCHETYPES = [
         profile: { bassMean: 0.2, midMean: 0.2, trebleMean: 0.25, centroidMean: 0.45, kickRate: 0.005, bassVariance: 0.003 },
         theme: {
             baseColor: [0, 40, 60], peakColor: [0, 180, 200], bgColor: [5, 10, 25],
-            ballCount: 3, speed: 1, fringeIntensity: 0.3,
-            routing: { radius: {bass:0.5,mid:0.5,treble:0.3}, speed: {bass:0,mid:0.3,treble:0.5}, color: {bass:0.3,mid:0.5,treble:1}, gradient: {bass:0.3,mid:0.5,treble:0.5}, fringe: {bass:0,mid:0.5,treble:1} },
+            ballCount: 3, speed: 1,            routing: { radius: {bass:0.5,mid:0.5,treble:0.3}, speed: {bass:0,mid:0.3,treble:0.5}, color: {bass:0.3,mid:0.5,treble:1}, gradient: {bass:0.3,mid:0.5,treble:0.5} },
             kickSensitivity: 2.5
         }
     },
@@ -60,8 +55,7 @@ const ARCHETYPES = [
         profile: { bassMean: 0.35, midMean: 0.3, trebleMean: 0.2, centroidMean: 0.35, kickRate: 0.04, bassVariance: 0.01 },
         theme: {
             baseColor: [120, 80, 50], peakColor: [220, 180, 140], bgColor: [40, 25, 15],
-            ballCount: 5, speed: 3, fringeIntensity: 0.2,
-            routing: { radius: {bass:1,mid:0.3,treble:0}, speed: {bass:0,mid:1,treble:0}, color: {bass:0,mid:0.5,treble:1}, gradient: {bass:0.5,mid:0.5,treble:0}, fringe: {bass:0,mid:0.7,treble:0.5} },
+            ballCount: 5, speed: 3,            routing: { radius: {bass:1,mid:0.3,treble:0}, speed: {bass:0,mid:1,treble:0}, color: {bass:0,mid:0.5,treble:1}, gradient: {bass:0.5,mid:0.5,treble:0} },
             kickSensitivity: 2.0
         }
     },
@@ -70,8 +64,7 @@ const ARCHETYPES = [
         profile: { bassMean: 0.55, midMean: 0.35, trebleMean: 0.4, centroidMean: 0.4, kickRate: 0.18, bassVariance: 0.015 },
         theme: {
             baseColor: [0, 30, 10], peakColor: [0, 255, 180], bgColor: [0, 0, 0],
-            ballCount: 9, speed: 6, fringeIntensity: 0.5,
-            routing: { radius: {bass:1,mid:0,treble:0}, speed: {bass:0,mid:1,treble:0.5}, color: {bass:0,mid:0,treble:1}, gradient: {bass:1,mid:0,treble:0}, fringe: {bass:0,mid:0,treble:1} },
+            ballCount: 9, speed: 6,            routing: { radius: {bass:1,mid:0,treble:0}, speed: {bass:0,mid:1,treble:0.5}, color: {bass:0,mid:0,treble:1}, gradient: {bass:1,mid:0,treble:0} },
             kickSensitivity: 1.4
         }
     },
@@ -80,8 +73,7 @@ const ARCHETYPES = [
         profile: { bassMean: 0.3, midMean: 0.45, trebleMean: 0.35, centroidMean: 0.55, kickRate: 0.03, bassVariance: 0.02 },
         theme: {
             baseColor: [60, 40, 10], peakColor: [220, 180, 60], bgColor: [20, 15, 5],
-            ballCount: 4, speed: 3, fringeIntensity: 0.15,
-            routing: { radius: {bass:0.7,mid:0.5,treble:0}, speed: {bass:0,mid:1,treble:0.3}, color: {bass:0,mid:0.7,treble:1}, gradient: {bass:0.5,mid:0.5,treble:0}, fringe: {bass:0,mid:0.5,treble:0.5} },
+            ballCount: 4, speed: 3,            routing: { radius: {bass:0.7,mid:0.5,treble:0}, speed: {bass:0,mid:1,treble:0.3}, color: {bass:0,mid:0.7,treble:1}, gradient: {bass:0.5,mid:0.5,treble:0} },
             kickSensitivity: 2.2
         }
     }

--- a/displays/ballDisplay.js
+++ b/displays/ballDisplay.js
@@ -4,8 +4,8 @@ let NUM_BALLS = 10;
 const R_MIN = 30;
 const R_MAX = 90;
 
-let BASE_COLOR = [0, 0, 0];
-let PEAK_COLOR = [255, 255, 255];
+let BASE_COLOR = [5, 2, 18];
+let PEAK_COLOR = [220, 240, 255];
 
 // functions for bringing changes from UI
 function setBaseColorFromHex(hex) {

--- a/displays/ballDisplay.js
+++ b/displays/ballDisplay.js
@@ -86,19 +86,6 @@ class Metaball {
         this.pulseLevel = 255;
     }
 
-    draw() {
-        // Color: max of routed band energy and kick pulse flash
-        const routing = AppSettings.routing;
-        const colorEnergy = bassEnergy * routing.color.bass + midEnergy * routing.color.mid + trebleEnergy * routing.color.treble;
-        let t = max(colorEnergy, this.pulseLevel / 255);
-        let r = lerp(BASE_COLOR[0], PEAK_COLOR[0], t);
-        let g = lerp(BASE_COLOR[1], PEAK_COLOR[1], t);
-        let b = lerp(BASE_COLOR[2], PEAK_COLOR[2], t);
-
-        noStroke();
-        fill(r, g, b);
-        circle(this.x, this.y, this.r * 2);
-    }
 }
 
 // initialize list of balls
@@ -120,18 +107,15 @@ function onEventDetected() {
     if (typeof triggerKickFlash === 'function') triggerKickFlash();
 }
 
-// draw the balls
+// draw the gradient field (balls are invisible attractors)
 function drawBall() {
     push();
     blendMode(BLEND);
-    if (USE_METAMERGE) {
-        drawMergedBlob();
-    } else {
-        for (const ball of balls) ball.draw();
-    }
+    drawGradientField();
     pop();
 }
 
 function windowResized() {
   resizeCanvas(windowWidth, windowHeight);
+  if (typeof resetGradientBuffer === 'function') resetGradientBuffer();
 }

--- a/displays/ballMerge.js
+++ b/displays/ballMerge.js
@@ -3,7 +3,7 @@
 // to a multi-stop color gradient via pixel buffer, with interference fringes.
 
 // --- configurable field parameters ---
-const FIELD_STEP = 8;        // grid spacing in pixels (larger = faster, blockier)
+const FIELD_STEP = 4;        // grid spacing in pixels (smaller = smoother, slower)
 const FIELD_NORM = 4.0;      // normalization divisor: fieldValue / FIELD_NORM maps to [0,1] for LUT
 
 // Cached pixel buffer for the gradient field
@@ -110,7 +110,9 @@ function drawGradientField() {
 
     _gradientImg.updatePixels();
 
-    // Upscale to full canvas — browser uses bilinear interpolation
+    // Enable bilinear smoothing for upscale (avoids blocky nearest-neighbor)
+    drawingContext.imageSmoothingEnabled = true;
+    drawingContext.imageSmoothingQuality = 'high';
     image(_gradientImg, 0, 0, width, height);
 }
 

--- a/displays/ballMerge.js
+++ b/displays/ballMerge.js
@@ -1,6 +1,6 @@
 // ballMerge.js
 // Gradient field renderer — maps the continuous metaball scalar field
-// to a multi-stop color gradient via pixel buffer, with interference fringes.
+// to a multi-stop color gradient via pixel buffer.
 
 // --- configurable field parameters ---
 const FIELD_STEP = 4;        // grid spacing in pixels (smaller = smoother, slower)
@@ -11,9 +11,6 @@ let _gradientImg = null;
 let _gradientCols = 0;
 let _gradientRows = 0;
 
-// Fringe animation constants
-const FRINGE_BASE_FREQ = 8.0;   // base frequency for sin() fringe pattern
-const FRINGE_BASE_SPEED = 0.03; // base animation speed
 
 // Scalar field: sum of r_i^2 / dist^2
 function fieldValueAt(px, py) {
@@ -56,18 +53,8 @@ function drawGradientField() {
     const gradientEnergy = bassEnergy * routing.gradient.bass +
                            midEnergy * routing.gradient.mid +
                            trebleEnergy * routing.gradient.treble;
-    const fringeEnergy = bassEnergy * routing.fringe.bass +
-                         midEnergy * routing.fringe.mid +
-                         trebleEnergy * routing.fringe.treble;
-
     // Gradient energy modulates the normalization — higher energy = wider gradient spread
     const normFactor = FIELD_NORM / (1 + gradientEnergy * 1.5);
-
-    // Fringe parameters
-    const fringeIntensity = AppSettings.fringeIntensity;
-    const fringeFreq = FRINGE_BASE_FREQ * (1 + fringeEnergy * 3);
-    const fringeSpeed = FRINGE_BASE_SPEED * (1 + fringeEnergy * 2);
-    const fringeTime = frameCount * fringeSpeed;
 
     _gradientImg.loadPixels();
     const pixels = _gradientImg.pixels;
@@ -89,16 +76,6 @@ function drawGradientField() {
             let r = lut[lutIndex * 4];
             let g = lut[lutIndex * 4 + 1];
             let b = lut[lutIndex * 4 + 2];
-
-            // Apply interference fringes
-            if (fringeIntensity > 0 && normalized > 0.01) {
-                const fringe = Math.sin(fieldVal * fringeFreq + fringeTime);
-                // Fringe modulates brightness: [-1,1] -> [1-intensity, 1+intensity]
-                const fringeMod = 1 + fringe * fringeIntensity * 0.5;
-                r = Math.min(255, Math.max(0, r * fringeMod));
-                g = Math.min(255, Math.max(0, g * fringeMod));
-                b = Math.min(255, Math.max(0, b * fringeMod));
-            }
 
             const idx = (row * cols + col) * 4;
             pixels[idx]     = r;

--- a/displays/ballMerge.js
+++ b/displays/ballMerge.js
@@ -1,30 +1,21 @@
 // ballMerge.js
-// Handles "merge" rendering so balls look like one blob (metaball style)
+// Gradient field renderer — maps the continuous metaball scalar field
+// to a multi-stop color gradient via pixel buffer, with interference fringes.
 
 // --- configurable field parameters ---
 const FIELD_STEP = 8;        // grid spacing in pixels (larger = faster, blockier)
-const FIELD_THRESHOLD = 1.9; // metaball threshold; tweak to taste
-let USE_METAMERGE = true;    // toggle: merged blob vs. individual circles
+const FIELD_NORM = 4.0;      // normalization divisor: fieldValue / FIELD_NORM maps to [0,1] for LUT
 
-// Scene-wide color: max of treble continuous warmth and kick pulse flash
-function getScenePulseT() {
-    if (balls.length === 0) return 0;
-    let m = 0;
-    for (const b of balls) if (b.pulseLevel > m) m = b.pulseLevel;
-    const routing = AppSettings.routing;
-    const colorEnergy = bassEnergy * routing.color.bass + midEnergy * routing.color.mid + trebleEnergy * routing.color.treble;
-    return max(colorEnergy, m / 255);
-}
+// Cached pixel buffer for the gradient field
+let _gradientImg = null;
+let _gradientCols = 0;
+let _gradientRows = 0;
 
-function getSceneColorRGB() {
-    const t = getScenePulseT();
-    const r = lerp(BASE_COLOR[0], PEAK_COLOR[0], t);
-    const g = lerp(BASE_COLOR[1], PEAK_COLOR[1], t);
-    const b = lerp(BASE_COLOR[2], PEAK_COLOR[2], t);
-    return [r, g, b];
-}
+// Fringe animation constants
+const FRINGE_BASE_FREQ = 8.0;   // base frequency for sin() fringe pattern
+const FRINGE_BASE_SPEED = 0.03; // base animation speed
 
-// Scalar field Σ r_i^2 / dist^2
+// Scalar field: sum of r_i^2 / dist^2
 function fieldValueAt(px, py) {
     let sum = 0;
     for (const b of balls) {
@@ -36,251 +27,94 @@ function fieldValueAt(px, py) {
     return sum;
 }
 
-// Linear interpolation along an edge to find where field crosses threshold
-// v0, v1: field values at the two endpoints
-// p0, p1: [x,y] coordinates of the two endpoints
-function interpEdge(v0, v1, p0x, p0y, p1x, p1y) {
-    const t = (FIELD_THRESHOLD - v0) / (v1 - v0);
-    return [
-        p0x + t * (p1x - p0x),
-        p0y + t * (p1y - p0y)
-    ];
-}
-
-// Marching squares edge lookup table
-// Bit ordering: bit0=TL(v0), bit1=TR(v1), bit2=BR(v2), bit3=BL(v3)
-// Edges: top=0(TL-TR), right=1(TR-BR), bottom=2(BR-BL), left=3(BL-TL)
-// Each case maps to a list of triangle fans (arrays of edge indices or corner indices)
-// We use a polygon-based approach: for each case, list the vertices (corners + edge crossings)
-// that form the filled region, in order.
-
-// Draw merged solid blob using marching squares (all 16 cases)
-function drawMergedBlob() {
-    const [cr, cg, cb] = getSceneColorRGB();
-    noStroke();
-    fill(cr, cg, cb, 255);
-
+// Ensure pixel buffer matches current canvas dimensions
+function _ensureGradientBuffer() {
     const cols = Math.ceil(width / FIELD_STEP) + 1;
     const rows = Math.ceil(height / FIELD_STEP) + 1;
+    if (!_gradientImg || cols !== _gradientCols || rows !== _gradientRows) {
+        _gradientImg = createImage(cols, rows);
+        _gradientCols = cols;
+        _gradientRows = rows;
+    }
+}
 
-    // Cache field values in a 2D grid
-    const grid = new Array(rows);
+// Draw the gradient field using pixel buffer
+function drawGradientField() {
+    if (balls.length === 0) return;
+
+    // Ensure LUT exists
+    if (!gradientLUT) rebuildGradientLUT();
+
+    _ensureGradientBuffer();
+
+    const cols = _gradientCols;
+    const rows = _gradientRows;
+    const lut = gradientLUT;
+
+    // Audio-reactive modulation via routing matrix
+    const routing = AppSettings.routing;
+    const gradientEnergy = bassEnergy * routing.gradient.bass +
+                           midEnergy * routing.gradient.mid +
+                           trebleEnergy * routing.gradient.treble;
+    const fringeEnergy = bassEnergy * routing.fringe.bass +
+                         midEnergy * routing.fringe.mid +
+                         trebleEnergy * routing.fringe.treble;
+
+    // Gradient energy modulates the normalization — higher energy = wider gradient spread
+    const normFactor = FIELD_NORM / (1 + gradientEnergy * 1.5);
+
+    // Fringe parameters
+    const fringeIntensity = AppSettings.fringeIntensity;
+    const fringeFreq = FRINGE_BASE_FREQ * (1 + fringeEnergy * 3);
+    const fringeSpeed = FRINGE_BASE_SPEED * (1 + fringeEnergy * 2);
+    const fringeTime = frameCount * fringeSpeed;
+
+    _gradientImg.loadPixels();
+    const pixels = _gradientImg.pixels;
+
     for (let row = 0; row < rows; row++) {
-        grid[row] = new Float32Array(cols);
         const py = row * FIELD_STEP;
         for (let col = 0; col < cols; col++) {
-            grid[row][col] = fieldValueAt(col * FIELD_STEP, py);
+            const px = col * FIELD_STEP;
+
+            // Compute scalar field value
+            const fieldVal = fieldValueAt(px, py);
+
+            // Normalize to [0, 1] and map to LUT index [0, 255]
+            const normalized = Math.min(fieldVal / normFactor, 1);
+            let lutIndex = Math.floor(normalized * 255);
+            if (lutIndex > 255) lutIndex = 255;
+
+            // Base color from LUT
+            let r = lut[lutIndex * 4];
+            let g = lut[lutIndex * 4 + 1];
+            let b = lut[lutIndex * 4 + 2];
+
+            // Apply interference fringes
+            if (fringeIntensity > 0 && normalized > 0.01) {
+                const fringe = Math.sin(fieldVal * fringeFreq + fringeTime);
+                // Fringe modulates brightness: [-1,1] -> [1-intensity, 1+intensity]
+                const fringeMod = 1 + fringe * fringeIntensity * 0.5;
+                r = Math.min(255, Math.max(0, r * fringeMod));
+                g = Math.min(255, Math.max(0, g * fringeMod));
+                b = Math.min(255, Math.max(0, b * fringeMod));
+            }
+
+            const idx = (row * cols + col) * 4;
+            pixels[idx]     = r;
+            pixels[idx + 1] = g;
+            pixels[idx + 2] = b;
+            pixels[idx + 3] = 255;
         }
     }
 
-    const T = FIELD_THRESHOLD;
+    _gradientImg.updatePixels();
 
-    for (let row = 0; row < rows - 1; row++) {
-        for (let col = 0; col < cols - 1; col++) {
-            const x = col * FIELD_STEP;
-            const y = row * FIELD_STEP;
-            const s = FIELD_STEP;
+    // Upscale to full canvas — browser uses bilinear interpolation
+    image(_gradientImg, 0, 0, width, height);
+}
 
-            // Corner values: TL=v0, TR=v1, BR=v2, BL=v3
-            const v0 = grid[row][col];         // TL
-            const v1 = grid[row][col + 1];     // TR
-            const v2 = grid[row + 1][col + 1]; // BR
-            const v3 = grid[row + 1][col];     // BL
-
-            // Bit field: bit0=TL, bit1=TR, bit2=BR, bit3=BL
-            const inside = (v0 >= T ? 1 : 0) |
-                           (v1 >= T ? 2 : 0) |
-                           (v2 >= T ? 4 : 0) |
-                           (v3 >= T ? 8 : 0);
-
-            if (inside === 0) continue;  // all outside
-            if (inside === 15) {
-                // all inside — fill entire cell
-                beginShape();
-                vertex(x, y);
-                vertex(x + s, y);
-                vertex(x + s, y + s);
-                vertex(x, y + s);
-                endShape(CLOSE);
-                continue;
-            }
-
-            // Edge interpolation points (computed on demand)
-            // Top edge: between TL and TR
-            let eTop, eRight, eBottom, eLeft;
-
-            // Case-by-case rendering
-            // Using the polygon approach: trace the boundary of the "inside" region
-            switch (inside) {
-                case 1: { // only TL inside
-                    eTop = interpEdge(v0, v1, x, y, x + s, y);
-                    eLeft = interpEdge(v0, v3, x, y, x, y + s);
-                    beginShape();
-                    vertex(x, y);
-                    vertex(eTop[0], eTop[1]);
-                    vertex(eLeft[0], eLeft[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 2: { // only TR inside
-                    eTop = interpEdge(v0, v1, x, y, x + s, y);
-                    eRight = interpEdge(v1, v2, x + s, y, x + s, y + s);
-                    beginShape();
-                    vertex(eTop[0], eTop[1]);
-                    vertex(x + s, y);
-                    vertex(eRight[0], eRight[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 3: { // TL + TR inside
-                    eRight = interpEdge(v1, v2, x + s, y, x + s, y + s);
-                    eLeft = interpEdge(v0, v3, x, y, x, y + s);
-                    beginShape();
-                    vertex(x, y);
-                    vertex(x + s, y);
-                    vertex(eRight[0], eRight[1]);
-                    vertex(eLeft[0], eLeft[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 4: { // only BR inside
-                    eRight = interpEdge(v1, v2, x + s, y, x + s, y + s);
-                    eBottom = interpEdge(v2, v3, x + s, y + s, x, y + s);
-                    beginShape();
-                    vertex(eRight[0], eRight[1]);
-                    vertex(x + s, y + s);
-                    vertex(eBottom[0], eBottom[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 5: { // TL + BR inside (saddle case)
-                    eTop = interpEdge(v0, v1, x, y, x + s, y);
-                    eRight = interpEdge(v1, v2, x + s, y, x + s, y + s);
-                    eBottom = interpEdge(v2, v3, x + s, y + s, x, y + s);
-                    eLeft = interpEdge(v0, v3, x, y, x, y + s);
-                    // Two separate triangles for the saddle
-                    beginShape();
-                    vertex(x, y);
-                    vertex(eTop[0], eTop[1]);
-                    vertex(eLeft[0], eLeft[1]);
-                    endShape(CLOSE);
-                    beginShape();
-                    vertex(eRight[0], eRight[1]);
-                    vertex(x + s, y + s);
-                    vertex(eBottom[0], eBottom[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 6: { // TR + BR inside
-                    eTop = interpEdge(v0, v1, x, y, x + s, y);
-                    eBottom = interpEdge(v2, v3, x + s, y + s, x, y + s);
-                    beginShape();
-                    vertex(eTop[0], eTop[1]);
-                    vertex(x + s, y);
-                    vertex(x + s, y + s);
-                    vertex(eBottom[0], eBottom[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 7: { // TL + TR + BR inside (BL outside)
-                    eBottom = interpEdge(v2, v3, x + s, y + s, x, y + s);
-                    eLeft = interpEdge(v0, v3, x, y, x, y + s);
-                    beginShape();
-                    vertex(x, y);
-                    vertex(x + s, y);
-                    vertex(x + s, y + s);
-                    vertex(eBottom[0], eBottom[1]);
-                    vertex(eLeft[0], eLeft[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 8: { // only BL inside
-                    eBottom = interpEdge(v2, v3, x + s, y + s, x, y + s);
-                    eLeft = interpEdge(v0, v3, x, y, x, y + s);
-                    beginShape();
-                    vertex(eBottom[0], eBottom[1]);
-                    vertex(x, y + s);
-                    vertex(eLeft[0], eLeft[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 9: { // TL + BL inside
-                    eTop = interpEdge(v0, v1, x, y, x + s, y);
-                    eBottom = interpEdge(v2, v3, x + s, y + s, x, y + s);
-                    beginShape();
-                    vertex(x, y);
-                    vertex(eTop[0], eTop[1]);
-                    vertex(eBottom[0], eBottom[1]);
-                    vertex(x, y + s);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 10: { // TR + BL inside (saddle case)
-                    eTop = interpEdge(v0, v1, x, y, x + s, y);
-                    eRight = interpEdge(v1, v2, x + s, y, x + s, y + s);
-                    eBottom = interpEdge(v2, v3, x + s, y + s, x, y + s);
-                    eLeft = interpEdge(v0, v3, x, y, x, y + s);
-                    // Two separate triangles for the saddle
-                    beginShape();
-                    vertex(eTop[0], eTop[1]);
-                    vertex(x + s, y);
-                    vertex(eRight[0], eRight[1]);
-                    endShape(CLOSE);
-                    beginShape();
-                    vertex(eBottom[0], eBottom[1]);
-                    vertex(x, y + s);
-                    vertex(eLeft[0], eLeft[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 11: { // TL + TR + BL inside (BR outside)
-                    eRight = interpEdge(v1, v2, x + s, y, x + s, y + s);
-                    eBottom = interpEdge(v2, v3, x + s, y + s, x, y + s);
-                    beginShape();
-                    vertex(x, y);
-                    vertex(x + s, y);
-                    vertex(eRight[0], eRight[1]);
-                    vertex(eBottom[0], eBottom[1]);
-                    vertex(x, y + s);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 12: { // BR + BL inside
-                    eRight = interpEdge(v1, v2, x + s, y, x + s, y + s);
-                    eLeft = interpEdge(v0, v3, x, y, x, y + s);
-                    beginShape();
-                    vertex(eRight[0], eRight[1]);
-                    vertex(x + s, y + s);
-                    vertex(x, y + s);
-                    vertex(eLeft[0], eLeft[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 13: { // TL + BR + BL inside (TR outside)
-                    eTop = interpEdge(v0, v1, x, y, x + s, y);
-                    eRight = interpEdge(v1, v2, x + s, y, x + s, y + s);
-                    beginShape();
-                    vertex(x, y);
-                    vertex(eTop[0], eTop[1]);
-                    vertex(eRight[0], eRight[1]);
-                    vertex(x + s, y + s);
-                    vertex(x, y + s);
-                    endShape(CLOSE);
-                    break;
-                }
-                case 14: { // TR + BR + BL inside (TL outside)
-                    eTop = interpEdge(v0, v1, x, y, x + s, y);
-                    eLeft = interpEdge(v0, v3, x, y, x, y + s);
-                    beginShape();
-                    vertex(eTop[0], eTop[1]);
-                    vertex(x + s, y);
-                    vertex(x + s, y + s);
-                    vertex(x, y + s);
-                    vertex(eLeft[0], eLeft[1]);
-                    endShape(CLOSE);
-                    break;
-                }
-            }
-        }
-    }
+// Recreate pixel buffer (call from windowResized)
+function resetGradientBuffer() {
+    _gradientImg = null;
 }

--- a/displays/gradientLUT.js
+++ b/displays/gradientLUT.js
@@ -1,0 +1,75 @@
+// gradientLUT.js
+// Generates a 256-entry RGBA lookup table from multi-stop gradient palettes.
+// Uses HSL shortest-arc interpolation via rgbToHsl()/hslToRgb() from settings.js.
+
+// The active LUT — a Uint8Array(256 * 4) of RGBA values.
+// Index by: lut[i * 4], lut[i * 4 + 1], lut[i * 4 + 2], lut[i * 4 + 3]
+let gradientLUT = null;
+
+// Generate a 256-entry RGBA LUT from an array of color stops.
+// Each stop: { position: 0-1, color: [r, g, b] }
+// Stops must be sorted by position ascending.
+function generateGradientLUT(stops) {
+    const lut = new Uint8Array(256 * 4);
+
+    if (!stops || stops.length < 2) {
+        // Fallback: black to white
+        for (let i = 0; i < 256; i++) {
+            lut[i * 4]     = i;
+            lut[i * 4 + 1] = i;
+            lut[i * 4 + 2] = i;
+            lut[i * 4 + 3] = 255;
+        }
+        return lut;
+    }
+
+    // Convert all stops to HSL for interpolation
+    const hslStops = stops.map(function(s) {
+        const hsl = rgbToHsl(s.color[0], s.color[1], s.color[2]);
+        return { position: s.position, h: hsl[0], s: hsl[1], l: hsl[2] };
+    });
+
+    for (let i = 0; i < 256; i++) {
+        const t = i / 255; // normalized position [0, 1]
+
+        // Find the two stops that bracket this position
+        let lower = hslStops[0];
+        let upper = hslStops[hslStops.length - 1];
+
+        for (let j = 0; j < hslStops.length - 1; j++) {
+            if (t >= hslStops[j].position && t <= hslStops[j + 1].position) {
+                lower = hslStops[j];
+                upper = hslStops[j + 1];
+                break;
+            }
+        }
+
+        // Interpolation factor within this segment
+        const range = upper.position - lower.position;
+        const segT = range > 0 ? (t - lower.position) / range : 0;
+
+        // HSL shortest-arc hue interpolation
+        let hDiff = upper.h - lower.h;
+        if (hDiff > 180) hDiff -= 360;
+        if (hDiff < -180) hDiff += 360;
+        let h = lower.h + hDiff * segT;
+        if (h < 0) h += 360;
+        if (h >= 360) h -= 360;
+
+        const s = lower.s + (upper.s - lower.s) * segT;
+        const l = lower.l + (upper.l - lower.l) * segT;
+
+        const rgb = hslToRgb(h, s, l);
+        lut[i * 4]     = rgb[0];
+        lut[i * 4 + 1] = rgb[1];
+        lut[i * 4 + 2] = rgb[2];
+        lut[i * 4 + 3] = 255;
+    }
+
+    return lut;
+}
+
+// Rebuild the active LUT from current AppSettings.palette
+function rebuildGradientLUT() {
+    gradientLUT = generateGradientLUT(AppSettings.palette);
+}

--- a/displays/spectrumDisplay.js
+++ b/displays/spectrumDisplay.js
@@ -1,15 +1,16 @@
 function displayFullSpectrum(spectrum) {
+    push();
     let w = width / spectrum.length*10;
     for (let i = 0; i < spectrum.length/10; i++) {
         // Map frequency amplitude to height
         let amp = spectrum[i];
         let h = map(amp, 0, 255, 0, height - 50);
-        
+
         // Create color based on frequency
         let hue = map(i, 0, spectrum.length, 0, 360);
         colorMode(HSB);
         fill(hue, 80, map(amp, 0, 255, 30, 100));
-        
+
         // Draw bar
         rect(i * w, height - h - 25, w - 1, h);
         if (amp > 50) {
@@ -17,5 +18,6 @@ function displayFullSpectrum(spectrum) {
             rect(i * w - 2, height - h - 27, w + 3, h + 4);
         }
     }
+    pop();
 }
 

--- a/docs/brainstorms/2026-04-07-holographic-gradient-core-requirements.md
+++ b/docs/brainstorms/2026-04-07-holographic-gradient-core-requirements.md
@@ -1,0 +1,63 @@
+---
+date: 2026-04-07
+topic: holographic-gradient-core
+---
+
+# Holographic Gradient Core
+
+## Problem Frame
+The current visualizer renders audio-reactive metaballs as flat-colored blobs via marching squares. The scalar field computes smooth continuous values but throws them away with a binary threshold. The result looks like bouncing circles, not the expressive gradient/holographic aesthetic the project is heading toward. This feature replaces the marching-squares renderer with a pixel-buffer gradient field, adds interference fringes for holographic shimmer, and upgrades the 2-color palette to a multi-stop gradient LUT system.
+
+## Requirements
+
+- R1. **Continuous gradient field renderer** — Replace the marching-squares binary threshold in `ballMerge.js` with a pixel-buffer renderer that maps the continuous scalar field values to colors via a gradient lookup table. Each grid cell's field value indexes into the LUT to produce smooth, full-canvas gradient visuals. Render at FIELD_STEP resolution into a `createImage()`/`pixels[]` buffer, upscaled to canvas size.
+
+- R2. **Multi-stop gradient LUT system** — Replace the 2-color base/peak lerp with a gradient lookup table (256 entries). The LUT is generated from user-defined color stops (minimum 2, up to 8). Ship with a default palette tuned for the default song (`pilsplaat.wav`). The palette data structure must be extensible so the theme engine can set it programmatically later (when ML pipeline is in place). Activate the existing unused `rgbToHsl()`/`hslToRgb()` utilities for HSL-space interpolation between stops.
+
+- R3. **Interference fringe overlay** — After the base gradient render pass, apply `sin(fieldValue * frequency + time * speed)` to modulate brightness and/or hue, producing concentric holographic rainbow bands around blob boundaries. Fringe frequency and animation speed are audio-reactive via the routing matrix.
+
+- R4. **Fringe intensity control** — Expose a `fringeIntensity` parameter (0-100%) in AppSettings, controllable via UI. At 0%, no fringes are visible (pure gradient). At 100%, fringes are fully prominent. Default somewhere in the 30-50% range.
+
+- R5. **Extended routing matrix** — Add new routing targets to `AppSettings.routing` for the gradient parameters: at minimum `gradient` (controls gradient spread/intensity) and `fringe` (controls fringe frequency/speed). Follows the existing `{ bass: N, mid: N, treble: N }` weight pattern so users can customize which bands drive which visual parameters.
+
+- R6. **Invisible ball attractors** — Ball physics (bouncing, kick reactions, velocity) continue to drive the scalar field positions. Balls are not rendered directly — the user sees only their influence on the gradient field as moving pools of color.
+
+- R7. **Palette customization UI** — Expose palette color stops in the UI so users can fully customize the gradient. The existing base/peak color pickers can evolve into gradient stop pickers, or a new palette section can be added.
+
+## Success Criteria
+- The visualizer produces smooth, full-canvas gradient visuals that react to audio across all three bands
+- Interference fringes create visible holographic shimmer that is adjustable from invisible to intense
+- The color palette supports more than two colors and interpolates smoothly in HSL space
+- Frame rate stays above 30fps at 1080p with 10 balls (current default)
+- The old marching-squares renderer is fully removed
+
+## Scope Boundaries
+- **Out of scope:** Display mode switching / mode abstraction (we're replacing, not adding alongside)
+- **Out of scope:** Theme engine ML integration (palette structure is ready for it, but no ML work here)
+- **Out of scope:** WebGL / shader-based rendering (staying in Canvas 2D)
+- **Out of scope:** Temporal trail buffer (separate feature, can layer on later)
+- **Out of scope:** Sine wave interference field formula swap (separate feature)
+
+## Key Decisions
+- **Replace, don't coexist:** The gradient field replaces the marching-squares blob entirely. No display mode toggle needed.
+- **Extend routing matrix:** New gradient/fringe parameters plug into the existing `AppSettings.routing` architecture rather than having separate band-mapping UI.
+- **HSL interpolation:** Use HSL space for gradient stop interpolation to avoid muddy RGB midpoints. Activates the currently unused utilities.
+- **Fully customizable palettes:** No preset-only system. Everything is user-adjustable, with a good default. Theme engine will auto-generate palettes later.
+
+## Dependencies / Assumptions
+- The scalar field computation (`fieldValueAt()`, grid caching) is kept as-is — only the rendering pass changes
+- `createImage()`/`pixels[]` performance at FIELD_STEP=8 resolution (~240x135 at 1080p) is sufficient for 30fps+ — this assumption should be validated early in implementation
+- The existing `rgbToHsl()`/`hslToRgb()` utilities are correct and performant enough for LUT generation (not per-frame, just on palette change)
+
+## Outstanding Questions
+
+### Deferred to Planning
+- [Affects R1][Technical] What upscaling method should be used for the low-res pixel buffer? `image()` with default bilinear, or a manual approach?
+- [Affects R2][Needs research] What's a good default palette for `pilsplaat.wav`? Likely needs visual iteration during implementation.
+- [Affects R3][Technical] Should fringe hue modulation use a fixed rainbow cycle or shift relative to the base gradient color at each pixel?
+- [Affects R4][Technical] How should `fringeIntensity` blend — multiplicative on the fringe amplitude, or a lerp between fringed and unfringed output?
+- [Affects R5][Technical] Exact routing target names and default weights for the new gradient/fringe routing entries.
+- [Affects R7][Technical] UI layout for palette stop editing — inline color pickers per stop, or a gradient bar widget?
+
+## Next Steps
+→ `/ce:plan` for structured implementation planning

--- a/docs/ideation/2026-04-07-holographic-gradient-ideation.md
+++ b/docs/ideation/2026-04-07-holographic-gradient-ideation.md
@@ -1,0 +1,88 @@
+---
+date: 2026-04-07
+topic: holographic-gradient-transition
+focus: transitioning from metaballs to expressive gradient visuals, holographic patterns, and waves
+---
+
+# Ideation: Holographic Gradient Transition
+
+## Codebase Context
+- p5.js vanilla JS audio-reactive visualizer, no build step, served via `npx serve`
+- Currently 2D canvas with CPU-side metaball scalar field rendering (FIELD_STEP=8px grid)
+- No WEBGL mode — canvas created in 2D mode
+- 2-color palette only (base + peak lerp). HSL utilities (rgbToHsl/hslToRgb) exist in settings.js but unused
+- Multi-band audio reactivity: bass/mid/treble energies drive radius, speed, color via routing matrix in AppSettings
+- displays/ has ballDisplay.js, ballMerge.js, spectrumDisplay.js — no display mode abstraction
+- drawBall() called unconditionally in sketch.js — no mode switcher
+- All state flows through AppSettings with setter-bridge pattern
+- No past learnings documented in docs/solutions/
+
+## Ranked Ideas
+
+### 1. Continuous Gradient Field
+**Description:** Replace marching-squares binary threshold with direct pixel-buffer writes. The scalar field already computed by fieldValueAt() maps to a multi-stop color gradient instead of inside/outside. Uses createImage()/pixels[] at FIELD_STEP resolution, upscaled by the browser.
+**Rationale:** The existing field math already contains the gradient data — the threshold throws it away. Removing the 16-case switch and writing colors via pixels[] is simpler code that produces richer output. At FIELD_STEP=8, only ~32K pixels to write.
+**Downsides:** Requires building a gradient LUT system. Low-resolution pixel buffer needs smooth upscaling.
+**Confidence:** 90%
+**Complexity:** Medium
+**Status:** Explored (2026-04-07)
+
+### 2. Interference Fringe Overlay
+**Description:** Second render pass: sin(fieldValue * frequency + time * speed) mapped to brightness/hue over the base gradient. Produces concentric rainbow bands around blob boundaries. Bass controls fringe spacing, treble controls animation speed.
+**Rationale:** This is literally how holograms work — interference fringes. One trig call per grid cell with zero additional field evaluation. Cheapest path to a genuinely holographic look.
+**Downsides:** Needs tuning to avoid visual noise. Fringe density must scale with canvas size.
+**Confidence:** 85%
+**Complexity:** Low
+**Status:** Explored (2026-04-07)
+
+### 3. Multi-Stop Gradient LUT with Band-Driven Crossfade
+**Description:** Replace 2-color base/peak lerp with 4-8 color lookup tables (256 entries each). Each archetype theme defines its own LUT. Band energies shift gradient stop positions or crossfade between LUTs. Activates the unused rgbToHsl()/hslToRgb() utilities.
+**Rationale:** The 2-color palette is the expressiveness bottleneck. A LUT is a single array lookup — near-zero cost. Band-driven stop shifts make bass, mid, and treble visually distinguishable in the color field.
+**Downsides:** Designing good palettes is a taste problem. Requires UI for palette selection.
+**Confidence:** 85%
+**Complexity:** Medium
+**Status:** Explored (2026-04-07)
+
+### 4. Sine Wave Interference Field
+**Description:** Replace metaball formula (r^2/d^2) with sin(d*freq - time*speed)/d. Balls become wave emitters. Bass=slow wide ripples, treble=tight fast fringes.
+**Rationale:** The project is called "sines" but has zero sine wave visuals. One-line formula swap in fieldValueAt() that changes output from blobs to waves. Interference patterns are the physical basis of holograms.
+**Downsides:** sin() more expensive than multiply — may need coarser FIELD_STEP. Aesthetic tuning non-trivial.
+**Confidence:** 70%
+**Complexity:** Medium-High
+**Status:** Unexplored
+
+### 5. Temporal Trail Buffer
+**Description:** Replace background() full-clear with semi-transparent wash (alpha 10-40, bass-driven). Previous frames persist and fade into flowing aurora-like ribbons.
+**Rationale:** 1-line change that transforms every other visual idea. Gradient fields become flowing light-paintings.
+**Downsides:** Classic Canvas2D ghosting (alpha never reaches true zero) requires threshold clear.
+**Confidence:** 95%
+**Complexity:** Low
+**Status:** Unexplored
+
+### 6. Radial Gradient Balls (Quick Win)
+**Description:** Replace circle() with drawingContext.createRadialGradient() in non-metamerge path. 5-line change for immediate soft glow effect.
+**Rationale:** Immediate visual upgrade from flat circles to glowing orbs. Works as fallback and proof-of-concept.
+**Downsides:** Not holographic on its own. Only affects non-metamerge path.
+**Confidence:** 95%
+**Complexity:** Low
+**Status:** Unexplored
+
+## Rejection Summary
+
+| # | Idea | Reason Rejected |
+|---|------|-----------------|
+| 1 | Chromatic Aberration | 3x rendering cost on CPU-bound pipeline; glitch aesthetic not holographic |
+| 2 | Canvas2D Filter Post-Processing | CSS blur is full-canvas CPU convolution; tanks framerate |
+| 3 | Gravitational Lensing | Dependent texture lookup is a shader op; catastrophically slow CPU-side |
+| 4 | FFT Waveform Mesh | Different visualizer entirely; abandons metaball field and ball physics |
+| 5 | Delaunay Gradient Mesh | Low-poly faceted look opposite of smooth holographic; needs external lib |
+| 6 | Band-Separated Layer Canvases | 3x field evaluation cost; implementation detail not a feature |
+| 7 | Display Mode Abstraction | Pure architecture with zero visual impact; build renderer first |
+| 8 | Multi-Threshold Isobands | Half-step toward continuous gradient; still flat bands with hard edges |
+| 9 | Perlin Noise Domain Warping | Expensive JS noise(); lava lamp not holographic; better as later modifier |
+| 10 | Spectral Centroid Hue Rotation | Global tint doesn't create gradients/patterns; too simple |
+| 11 | Radial Gradient Compositing | 20 large overlapping radial fills hammer compositor; loses merge topology |
+
+## Session Log
+- 2026-04-07: Initial ideation — 40 candidates generated (5 sub-agents), 17 unique after dedup, 6 survived adversarial filtering
+- 2026-04-07: User selected ideas #1+#2+#3 ("Holographic Gradient Core" combo) for brainstorming on new branch from main

--- a/docs/plans/2026-04-07-001-feat-holographic-gradient-core-plan.md
+++ b/docs/plans/2026-04-07-001-feat-holographic-gradient-core-plan.md
@@ -1,0 +1,194 @@
+---
+title: "feat: Holographic gradient core renderer"
+type: feat
+status: active
+date: 2026-04-07
+origin: docs/brainstorms/2026-04-07-holographic-gradient-core-requirements.md
+---
+
+# feat: Holographic Gradient Core Renderer
+
+## Overview
+
+Replace the marching-squares metaball renderer with a pixel-buffer gradient field that maps the continuous scalar field to multi-stop color gradients, adds interference fringe overlays for holographic shimmer, and extends the routing matrix with new audio-reactive targets. Balls become invisible attractors driving pools of flowing color.
+
+## Problem Statement / Motivation
+
+The current renderer (287 lines of marching squares in `ballMerge.js`) computes a smooth continuous scalar field via `fieldValueAt()` then throws away all gradient information by thresholding to a binary inside/outside decision. The result is flat-colored blobs. The scalar field already contains the data needed for rich gradient visuals — this feature reinterprets it as color rather than geometry. (see origin: `docs/brainstorms/2026-04-07-holographic-gradient-core-requirements.md`)
+
+## Proposed Solution
+
+Three layered changes that compose into one cohesive visual upgrade:
+
+1. **Pixel-buffer gradient renderer** — Walk the FIELD_STEP grid, index each cell's field value into a 256-entry color LUT, write RGBA into a low-res `createImage()` buffer, upscale via `image()`. Replaces all marching-squares code.
+2. **Multi-stop gradient LUT** — Generate a 256-entry color array from 2-8 user-defined HSL-interpolated stops. Regenerated on palette change. `baseColor`/`peakColor` become aliases for stop[0] and stop[N-1] for backward compatibility with the theme engine.
+3. **Interference fringe overlay** — After base gradient, modulate each pixel with `sin(fieldValue * fringeFreq + frameCount * fringeSpeed)` scaled by `fringeIntensity` (0-100%). Produces concentric holographic rainbow bands.
+
+## Technical Considerations
+
+### Architecture
+
+- The scalar field computation (`fieldValueAt()`, grid caching, ball loop) is unchanged — only the rendering pass after the grid is computed changes
+- `baseColor`/`peakColor` are kept in AppSettings and SETTINGS_SCHEMA as aliases for palette stop[0] and stop[N-1]. The setter bridge, theme engine, and lock pins continue to work. When either is set, the corresponding palette stop updates. When the palette is set directly, baseColor/peakColor sync.
+- `metaMode` is deprecated. The gradient field always renders. Archetypes that set `metaMode: false` (Calm Classical, Lo-Fi Chill, Jazz) differentiate via palette, ball count, speed, and fringe settings instead of a separate rendering path.
+- New routing targets `gradient` and `fringe` follow the existing `{ bass: N, mid: N, treble: N }` weight pattern
+
+### Performance
+
+- At 1080p with FIELD_STEP=8: grid is ~240x135 = 32,400 cells
+- Field evaluation: 10 balls × 32,400 cells = 324,000 distance calculations (unchanged from current)
+- LUT lookup: O(1) per cell (array index)
+- Fringe sin(): 32,400 calls per frame — trivial on modern hardware
+- Pixel buffer is low-res (`createImage(cols, rows)`) — `loadPixels()`/`updatePixels()` operates on ~130KB, not the full canvas
+- Upscaling via `image()` uses browser's hardware-accelerated bilinear interpolation
+- Target: 30fps+ at 1080p with 10 balls (matches origin spec)
+
+### Pre-existing Bug Fix
+
+- `spectrumDisplay.js:10` calls `colorMode(HSB)` without restoring RGB, which will corrupt the gradient renderer's pixel writes if spectrum is drawn in the same frame. Wrap in `push()`/`pop()`.
+
+## Implementation Phases
+
+### Phase 1: Gradient LUT System (`settings.js`, new `displays/gradientLUT.js`)
+
+**Goal:** Build the palette data model and LUT generator before touching the renderer.
+
+**Tasks:**
+- [ ] Create `displays/gradientLUT.js` with:
+  - `generateGradientLUT(stops)` → returns `Uint8Array(256 * 4)` (RGBA) using HSL shortest-arc interpolation between stops
+  - Each stop: `{ position: 0-1, color: [r, g, b] }`
+  - Shortest-arc HSL hue interpolation using existing `rgbToHsl()`/`hslToRgb()`
+- [ ] Add to `SETTINGS_SCHEMA`: `{ id: 'palette', type: 'palette', label: 'Gradient Palette', default: [{position: 0, color: [0,0,0]}, {position: 1, color: [255,255,255]}] }`
+- [ ] Add to `SETTINGS_SCHEMA`: `{ id: 'fringeIntensity', type: 'float', label: 'Fringe Intensity', min: 0, max: 1, default: 0.4 }`
+- [ ] Add `'palette'` type validation to `_validateSetting()`: clamp stop count to [2,8], ensure positions ordered in [0,1], validate color arrays
+- [ ] Add `palette` and `fringeIntensity` to `AppSettings` defaults
+- [ ] Add `palette` setter to `_setterMap` that: updates AppSettings.palette, regenerates the LUT, syncs `baseColor`←stop[0] and `peakColor`←stop[N-1]
+- [ ] Add `baseColor`/`peakColor` setter bridge: when either changes, update the corresponding palette stop and regenerate LUT
+- [ ] Add `fringeIntensity` setter to `_setterMap`
+- [ ] Extend `AppSettings.routing` default with: `gradient: { bass: 0.5, mid: 0.3, treble: 0.2 }`, `fringe: { bass: 0, mid: 0.3, treble: 1 }`
+- [ ] Add `<script src="displays/gradientLUT.js" defer></script>` to `index.html` (before `ballMerge.js`)
+
+**Files:** `settings.js`, `displays/gradientLUT.js` (new), `index.html`
+
+### Phase 2: Pixel-Buffer Gradient Renderer (`displays/ballMerge.js`)
+
+**Goal:** Replace marching squares with pixel-buffer gradient writes.
+
+**Tasks:**
+- [ ] Remove all marching-squares code: `interpEdge()`, the 16-case switch in `drawMergedBlob()`, the `FIELD_THRESHOLD` constant
+- [ ] Rewrite `drawMergedBlob()` as `drawGradientField()`:
+  1. Compute grid of field values (reuse existing grid cache logic)
+  2. Create or reuse a `p5.Image` at grid resolution (`cols × rows`)
+  3. `loadPixels()` on the image
+  4. For each grid cell: normalize field value → clamp to [0, 255] → index into LUT → write RGBA into `pixels[]`
+  5. Apply fringe: `sin(fieldValue * fringeFreq + frameCount * fringeSpeed)` modulates the pixel, blended by `fringeIntensity`
+  6. `updatePixels()` on the image
+  7. `image(gradientImg, 0, 0, width, height)` to upscale to canvas
+- [ ] Field value normalization: map raw field value range to [0, 255] for LUT indexing. Use a configurable normalization factor (field values near ball centers are very high, edges approach 0). Consider: `lutIndex = constrain(floor(fieldValue / maxExpectedField * 255), 0, 255)` where maxExpectedField is tuned to the visual.
+- [ ] Read routing matrix for audio-reactive modulation:
+  - `gradient` routing target modulates the normalization factor (bass makes gradients spread wider)
+  - `fringe` routing target modulates fringe frequency and/or speed
+- [ ] Cache the `p5.Image` — only recreate on window resize
+- [ ] Update `windowResized()` to recreate the pixel buffer
+- [ ] Remove `getScenePulseT()` and `getSceneColorRGB()` (no longer needed — color comes from LUT)
+- [ ] Update `drawBall()` in `ballDisplay.js`: always call `drawGradientField()`, remove the `USE_METAMERGE` branch and individual `ball.draw()` path. `Metaball.draw()` method can be removed.
+- [ ] Fix `spectrumDisplay.js`: wrap `displayFullSpectrum()` body in `push()`/`pop()` to isolate `colorMode(HSB)`
+
+**Files:** `displays/ballMerge.js`, `displays/ballDisplay.js`, `displays/spectrumDisplay.js`
+
+### Phase 3: Theme Engine + Routing UI Updates
+
+**Goal:** Wire new settings into theme engine archetypes and the Advanced panel routing matrix.
+
+**Tasks:**
+- [ ] Add `fringeIntensity` and extended routing (`gradient`, `fringe`) to all 8 archetypes in `themeEngine.js`. Suggested defaults:
+  - Dark Trap: fringeIntensity 0.5, gradient {bass:1, mid:0, treble:0}, fringe {bass:0, mid:0.3, treble:1}
+  - Bright Pop: fringeIntensity 0.3, gradient {bass:0.5, mid:0.5, treble:0}, fringe {bass:0, mid:0.5, treble:1}
+  - Calm Classical: fringeIntensity 0.1, gradient {bass:0.3, mid:0.5, treble:0.3}, fringe {bass:0, mid:0.5, treble:0.5}
+  - Heavy Metal: fringeIntensity 0.6, gradient {bass:1, mid:0.3, treble:0}, fringe {bass:0, mid:0, treble:1}
+  - Ambient: fringeIntensity 0.3, gradient {bass:0.3, mid:0.5, treble:0.5}, fringe {bass:0, mid:0.5, treble:1}
+  - Lo-Fi Chill: fringeIntensity 0.2, gradient {bass:0.5, mid:0.5, treble:0}, fringe {bass:0, mid:0.7, treble:0.5}
+  - Techno House: fringeIntensity 0.5, gradient {bass:1, mid:0, treble:0}, fringe {bass:0, mid:0, treble:1}
+  - Jazz: fringeIntensity 0.15, gradient {bass:0.5, mid:0.5, treble:0}, fringe {bass:0, mid:0.5, treble:0.5}
+- [ ] Remove `metaMode` from archetype themes (deprecated — gradient always renders)
+- [ ] Update `advancedControls.js` routing matrix UI: add `gradient` and `fringe` columns to the band routing grid. Update `params` array from `['radius', 'speed', 'color']` to `['radius', 'speed', 'color', 'gradient', 'fringe']` and `colLabels` accordingly
+- [ ] Deprecate `metaMode` in `ballControls.js` — remove the toggle or gray it out with a note
+
+**Files:** `detections/themeEngine.js`, `ui/advancedControls.js`, `ui/ballControls.js`
+
+### Phase 4: Palette Customization UI
+
+**Goal:** Let users add/remove/edit gradient color stops.
+
+**Tasks:**
+- [ ] Add a "Gradient" collapsible section in `setupUI()` (after Colors, before Ball Settings)
+- [ ] For each palette stop: render a row with a color picker and a position slider (0.0-1.0)
+- [ ] Add "+" button to add a stop (up to 8), "-" button to remove (minimum 2)
+- [ ] On any change: update `AppSettings.palette`, regenerate LUT, sync `baseColor`/`peakColor` if stop[0] or stop[N-1] changed
+- [ ] Add fringe intensity slider to the Gradient section using `_advancedSliderRow()` pattern
+- [ ] Register UI sync for `palette` and `fringeIntensity` so `applySettings()` can update the UI
+- [ ] Create new file `ui/gradientControls.js` and add to `index.html` (before `ui/index.js`)
+
+**Files:** `ui/gradientControls.js` (new), `ui/index.js`, `index.html`
+
+### Phase 5: Polish + Default Palette
+
+**Goal:** Tune the default palette for `pilsplaat.wav`, set good normalization values, verify performance.
+
+**Tasks:**
+- [ ] Tune field value normalization factor by running with the default song — ensure the gradient fills the canvas attractively with 10 balls
+- [ ] Design default palette (iterative — try HSL-spread palettes, warm-to-cool progressions, etc.)
+- [ ] Tune default fringe frequency and speed constants
+- [ ] Verify 30fps+ at 1080p with 10 balls in Chrome/Firefox/Safari
+- [ ] Verify window resize recreates the pixel buffer correctly
+- [ ] Test theme engine transitions — ensure new params apply and UI syncs
+- [ ] Remove dead code: `FIELD_THRESHOLD`, `interpEdge()`, any remaining marching-squares references
+
+**Files:** All modified files, manual testing
+
+## System-Wide Impact
+
+- **Settings architecture**: New settings (`palette`, `fringeIntensity`) and extended routing targets (`gradient`, `fringe`) flow through the existing `SETTINGS_SCHEMA` → `_setterMap` → `_validateSetting()` → `_syncUI()` pipeline. `baseColor`/`peakColor` gain bidirectional alias behavior with palette stops.
+- **Theme engine**: All 8 archetypes gain `fringeIntensity` and extended routing weights. `metaMode` is deprecated. Archetypes differentiate via palette, fringe, and routing instead of rendering-path toggles.
+- **Rendering pipeline**: `drawBall()` always calls `drawGradientField()`. Individual ball rendering (`Metaball.draw()`) is removed. Ball physics (update, bounce, kick) are unchanged.
+- **Script loading**: Two new `<script defer>` tags in `index.html`: `gradientLUT.js` (before `ballMerge.js`) and `gradientControls.js` (before `ui/index.js`).
+
+## Acceptance Criteria
+
+- [ ] Full-canvas smooth gradient visuals that react to audio across all three bands
+- [ ] Interference fringes produce visible holographic shimmer, adjustable from 0% (invisible) to 100% (intense)
+- [ ] Palette supports 2-8 color stops with HSL shortest-arc interpolation
+- [ ] `baseColor`/`peakColor` remain functional as aliases for first/last palette stops
+- [ ] Extended routing matrix (gradient, fringe targets) works in the Advanced panel UI
+- [ ] Theme engine applies new settings (fringeIntensity, routing) per archetype
+- [ ] Frame rate ≥ 30fps at 1080p with 10 balls
+- [ ] Window resize handled without artifacts
+- [ ] `spectrumDisplay.js` colorMode(HSB) leak fixed
+- [ ] All marching-squares code removed
+
+## Dependencies & Risks
+
+- **Performance assumption**: `createImage()` at ~240x135 with `loadPixels()`/`updatePixels()` + `image()` upscale must hit 30fps. Validate early in Phase 2. If too slow, increase FIELD_STEP to 12 or 16.
+- **Visual tuning**: Field value normalization and default palette require iterative tuning with audio playing. Cannot be determined in advance.
+- **HSL hue wrapping**: Shortest-arc interpolation must correctly handle the 0/360 boundary. Edge case: stops at H=350 and H=10 should interpolate through 0, not through 180.
+
+## Sources & References
+
+### Origin
+
+- **Origin document:** [docs/brainstorms/2026-04-07-holographic-gradient-core-requirements.md](docs/brainstorms/2026-04-07-holographic-gradient-core-requirements.md) — Key decisions: replace (don't coexist) marching-squares renderer, fully customizable palettes with good defaults, extend routing matrix for gradient/fringe targets, balls as invisible attractors, adjustable fringe intensity knob.
+
+### Internal References
+
+- Scalar field computation: `displays/ballMerge.js:28-36` (`fieldValueAt()`)
+- Grid caching: `displays/ballMerge.js:66-74`
+- Settings architecture: `settings.js:51-236` (schema, AppSettings, setter bridge, validation, applySettings)
+- Routing matrix: `settings.js:65-69`, `ui/advancedControls.js:28-58`
+- HSL utilities: `settings.js:8-49` (`rgbToHsl`, `hslToRgb`)
+- Theme archetypes: `detections/themeEngine.js:7-88`
+- UI pattern: `ui/index.js:8-38` (collapsible sections), `ui/advancedControls.js:123-149` (slider rows)
+- colorMode leak: `displays/spectrumDisplay.js:10`
+
+### Ideation
+
+- [docs/ideation/2026-04-07-holographic-gradient-ideation.md](docs/ideation/2026-04-07-holographic-gradient-ideation.md) — 40 candidates generated, 6 survivors, ideas #1+#2+#3 selected as "Holographic Gradient Core" combo

--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <script src="detections/kickDetection.js" defer></script>
         <script src="detections/audioFeatures.js" defer></script>
         <script src="detections/themeEngine.js" defer></script>
+        <script src="displays/gradientLUT.js" defer></script>
         <script src="displays/ballDisplay.js" defer></script>
         <script src="displays/ballMerge.js" defer></script>
         <script src="ui/debugOverlay.js" defer></script>

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
         <script src="ui/ballControls.js" defer></script>
         <script src="ui/audioControls.js" defer></script>
         <script src="ui/themeControls.js" defer></script>
+        <script src="ui/gradientControls.js" defer></script>
         <script src="ui/advancedControls.js" defer></script>
         <script src="ui/titleDisplay.js" defer></script>
         <script src="ui/index.js" defer></script>

--- a/settings.js
+++ b/settings.js
@@ -62,7 +62,6 @@ const SETTINGS_SCHEMA = [
     { id: 'kickCooldown',     type: 'int',     label: 'Kick Cooldown (ms)', min: 50, max: 1000, default: 200 },
     { id: 'kickFloor',        type: 'float',   label: 'Kick Floor',         min: 0, max: 100, default: 15 },
     { id: 'reactivity',       type: 'float',   label: 'Reactivity',         min: 0.1, max: 5, default: 1.0 },
-    { id: 'fringeIntensity',  type: 'float',   label: 'Fringe Intensity',   min: 0, max: 1, default: 0.4 },
     { id: 'palette',          type: 'palette', label: 'Gradient Palette',   default: [
         { position: 0,    color: [5, 2, 18] },
         { position: 0.35, color: [20, 60, 120] },
@@ -74,7 +73,7 @@ const SETTINGS_SCHEMA = [
         speed:    { bass: 0, mid: 1, treble: 0 },
         color:    { bass: 0, mid: 0, treble: 1 },
         gradient: { bass: 0.5, mid: 0.3, treble: 0.2 },
-        fringe:   { bass: 0, mid: 0.3, treble: 1 }
+
     }}
 ];
 
@@ -92,7 +91,6 @@ const AppSettings = {
     kickCooldown:    200,
     kickFloor:       15,
     reactivity:      1.0,
-    fringeIntensity: 0.4,
     palette: [
         { position: 0,    color: [5, 2, 18] },
         { position: 0.35, color: [20, 60, 120] },
@@ -104,7 +102,7 @@ const AppSettings = {
         speed:    { bass: 0, mid: 1, treble: 0 },
         color:    { bass: 0, mid: 0, treble: 1 },
         gradient: { bass: 0.5, mid: 0.3, treble: 0.2 },
-        fringe:   { bass: 0, mid: 0.3, treble: 1 }
+
     }
 };
 
@@ -192,9 +190,6 @@ const _setterMap = {
     reactivity: function(val) {
         AppSettings.reactivity = val;
         // reactivity is read directly from AppSettings in applyNoiseFloor()
-    },
-    fringeIntensity: function(val) {
-        AppSettings.fringeIntensity = val;
     },
     palette: function(val) {
         AppSettings.palette = JSON.parse(JSON.stringify(val));

--- a/settings.js
+++ b/settings.js
@@ -62,10 +62,17 @@ const SETTINGS_SCHEMA = [
     { id: 'kickCooldown',     type: 'int',     label: 'Kick Cooldown (ms)', min: 50, max: 1000, default: 200 },
     { id: 'kickFloor',        type: 'float',   label: 'Kick Floor',         min: 0, max: 100, default: 15 },
     { id: 'reactivity',       type: 'float',   label: 'Reactivity',         min: 0.1, max: 5, default: 1.0 },
+    { id: 'fringeIntensity',  type: 'float',   label: 'Fringe Intensity',   min: 0, max: 1, default: 0.4 },
+    { id: 'palette',          type: 'palette', label: 'Gradient Palette',   default: [
+        { position: 0,   color: [0, 0, 0] },
+        { position: 1,   color: [255, 255, 255] }
+    ]},
     { id: 'routing',          type: 'object',  label: 'Band Routing',       default: {
-        radius: { bass: 1, mid: 0, treble: 0 },
-        speed:  { bass: 0, mid: 1, treble: 0 },
-        color:  { bass: 0, mid: 0, treble: 1 }
+        radius:   { bass: 1, mid: 0, treble: 0 },
+        speed:    { bass: 0, mid: 1, treble: 0 },
+        color:    { bass: 0, mid: 0, treble: 1 },
+        gradient: { bass: 0.5, mid: 0.3, treble: 0.2 },
+        fringe:   { bass: 0, mid: 0.3, treble: 1 }
     }}
 ];
 
@@ -83,10 +90,17 @@ const AppSettings = {
     kickCooldown:    200,
     kickFloor:       15,
     reactivity:      1.0,
+    fringeIntensity: 0.4,
+    palette: [
+        { position: 0, color: [0, 0, 0] },
+        { position: 1, color: [255, 255, 255] }
+    ],
     routing: {
-        radius: { bass: 1, mid: 0, treble: 0 },
-        speed:  { bass: 0, mid: 1, treble: 0 },
-        color:  { bass: 0, mid: 0, treble: 1 }
+        radius:   { bass: 1, mid: 0, treble: 0 },
+        speed:    { bass: 0, mid: 1, treble: 0 },
+        color:    { bass: 0, mid: 0, treble: 1 },
+        gradient: { bass: 0.5, mid: 0.3, treble: 0.2 },
+        fringe:   { bass: 0, mid: 0.3, treble: 1 }
     }
 };
 
@@ -117,11 +131,21 @@ const _setterMap = {
         AppSettings.baseColor = val.slice();
         if (typeof setBaseColorFromHex === 'function') setBaseColorFromHex(_rgbToHex(val));
         else if (typeof BASE_COLOR !== 'undefined') BASE_COLOR = val.slice();
+        // Sync palette stop[0]
+        if (AppSettings.palette && AppSettings.palette.length >= 2) {
+            AppSettings.palette[0].color = val.slice();
+            if (typeof rebuildGradientLUT === 'function') rebuildGradientLUT();
+        }
     },
     peakColor: function(val) {
         AppSettings.peakColor = val.slice();
         if (typeof setPeakColorFromHex === 'function') setPeakColorFromHex(_rgbToHex(val));
         else if (typeof PEAK_COLOR !== 'undefined') PEAK_COLOR = val.slice();
+        // Sync palette stop[N-1]
+        if (AppSettings.palette && AppSettings.palette.length >= 2) {
+            AppSettings.palette[AppSettings.palette.length - 1].color = val.slice();
+            if (typeof rebuildGradientLUT === 'function') rebuildGradientLUT();
+        }
     },
     bgColor: function(val) {
         AppSettings.bgColor = val.slice();
@@ -165,6 +189,20 @@ const _setterMap = {
         AppSettings.reactivity = val;
         // reactivity is read directly from AppSettings in applyNoiseFloor()
     },
+    fringeIntensity: function(val) {
+        AppSettings.fringeIntensity = val;
+    },
+    palette: function(val) {
+        AppSettings.palette = JSON.parse(JSON.stringify(val));
+        // Sync baseColor/peakColor from first/last stops
+        if (val.length >= 2) {
+            AppSettings.baseColor = val[0].color.slice();
+            AppSettings.peakColor = val[val.length - 1].color.slice();
+            if (typeof BASE_COLOR !== 'undefined') BASE_COLOR = val[0].color.slice();
+            if (typeof PEAK_COLOR !== 'undefined') PEAK_COLOR = val[val.length - 1].color.slice();
+        }
+        if (typeof rebuildGradientLUT === 'function') rebuildGradientLUT();
+    },
     routing: function(val) {
         AppSettings.routing = JSON.parse(JSON.stringify(val));
         // routing is read directly from AppSettings by the band-routing system
@@ -190,6 +228,24 @@ function _validateSetting(key, val) {
         }
     } else if (schema.type === 'bool') {
         val = !!val;
+    } else if (schema.type === 'palette') {
+        if (!Array.isArray(val) || val.length < 2) {
+            val = schema.default;
+        } else {
+            // Clamp to 2-8 stops
+            if (val.length > 8) val = val.slice(0, 8);
+            // Validate each stop
+            val = val.map(function(stop) {
+                return {
+                    position: Math.max(0, Math.min(1, stop.position || 0)),
+                    color: Array.isArray(stop.color) ?
+                        stop.color.map(function(v) { return Math.round(Math.max(0, Math.min(255, v))); }) :
+                        [0, 0, 0]
+                };
+            });
+            // Sort by position
+            val.sort(function(a, b) { return a.position - b.position; });
+        }
     }
     return val;
 }

--- a/settings.js
+++ b/settings.js
@@ -51,8 +51,8 @@ function hslToRgb(h, s, l) {
 // ── Schema descriptors (for future UI generation) ──────────────────────────
 
 const SETTINGS_SCHEMA = [
-    { id: 'baseColor',        type: 'color',   label: 'Base Color',         default: [0, 0, 0] },
-    { id: 'peakColor',        type: 'color',   label: 'Peak Color',         default: [255, 255, 255] },
+    { id: 'baseColor',        type: 'color',   label: 'Base Color',         default: [5, 2, 18] },
+    { id: 'peakColor',        type: 'color',   label: 'Peak Color',         default: [220, 240, 255] },
     { id: 'bgColor',          type: 'color',   label: 'Background Color',   default: [0, 0, 0] },
     { id: 'ballCount',        type: 'int',     label: 'Ball Count',         min: 1, max: 20, default: 10 },
     { id: 'speed',            type: 'int',     label: 'Speed',              min: 1, max: 10, default: 4 },
@@ -64,8 +64,10 @@ const SETTINGS_SCHEMA = [
     { id: 'reactivity',       type: 'float',   label: 'Reactivity',         min: 0.1, max: 5, default: 1.0 },
     { id: 'fringeIntensity',  type: 'float',   label: 'Fringe Intensity',   min: 0, max: 1, default: 0.4 },
     { id: 'palette',          type: 'palette', label: 'Gradient Palette',   default: [
-        { position: 0,   color: [0, 0, 0] },
-        { position: 1,   color: [255, 255, 255] }
+        { position: 0,    color: [5, 2, 18] },
+        { position: 0.35, color: [20, 60, 120] },
+        { position: 0.65, color: [0, 180, 200] },
+        { position: 1,    color: [220, 240, 255] }
     ]},
     { id: 'routing',          type: 'object',  label: 'Band Routing',       default: {
         radius:   { bass: 1, mid: 0, treble: 0 },
@@ -79,8 +81,8 @@ const SETTINGS_SCHEMA = [
 // ── AppSettings — the canonical state object ───────────────────────────────
 
 const AppSettings = {
-    baseColor:       [0, 0, 0],
-    peakColor:       [255, 255, 255],
+    baseColor:       [5, 2, 18],
+    peakColor:       [220, 240, 255],
     bgColor:         [0, 0, 0],
     ballCount:       10,
     speed:           4,
@@ -92,8 +94,10 @@ const AppSettings = {
     reactivity:      1.0,
     fringeIntensity: 0.4,
     palette: [
-        { position: 0, color: [0, 0, 0] },
-        { position: 1, color: [255, 255, 255] }
+        { position: 0,    color: [5, 2, 18] },
+        { position: 0.35, color: [20, 60, 120] },
+        { position: 0.65, color: [0, 180, 200] },
+        { position: 1,    color: [220, 240, 255] }
     ],
     routing: {
         radius:   { bass: 1, mid: 0, treble: 0 },
@@ -163,7 +167,7 @@ const _setterMap = {
     },
     metaMode: function(val) {
         AppSettings.metaMode = val;
-        if (typeof USE_METAMERGE !== 'undefined') USE_METAMERGE = val;
+        // metaMode is deprecated — gradient field always renders
     },
     cleanDisplay: function(val) {
         AppSettings.cleanDisplay = val;

--- a/ui/advancedControls.js
+++ b/ui/advancedControls.js
@@ -16,7 +16,7 @@ function setupAdvancedControls(container) {
         .style('align-items', 'center')
         .style('margin-bottom', '2px');
     createDiv('').parent(headerRow).style('width', '50px'); // spacer for row label
-    const colLabels = ['Radius', 'Speed', 'Color', 'Gradient', 'Fringe'];
+    const colLabels = ['Radius', 'Speed', 'Color', 'Gradient'];
     for (const label of colLabels) {
         createDiv(label).parent(headerRow)
             .style('width', '60px')
@@ -26,7 +26,7 @@ function setupAdvancedControls(container) {
     }
 
     const bands = ['bass', 'mid', 'treble'];
-    const params = ['radius', 'speed', 'color', 'gradient', 'fringe'];
+    const params = ['radius', 'speed', 'color', 'gradient'];
     const bandLabels = { bass: 'Bass', mid: 'Mid', treble: 'Treble' };
 
     for (const band of bands) {

--- a/ui/advancedControls.js
+++ b/ui/advancedControls.js
@@ -16,17 +16,17 @@ function setupAdvancedControls(container) {
         .style('align-items', 'center')
         .style('margin-bottom', '2px');
     createDiv('').parent(headerRow).style('width', '50px'); // spacer for row label
-    const colLabels = ['Radius', 'Speed', 'Color'];
+    const colLabels = ['Radius', 'Speed', 'Color', 'Gradient', 'Fringe'];
     for (const label of colLabels) {
         createDiv(label).parent(headerRow)
-            .style('width', '70px')
+            .style('width', '60px')
             .style('text-align', 'center')
             .style('color', '#999')
             .style('font-size', '10px');
     }
 
     const bands = ['bass', 'mid', 'treble'];
-    const params = ['radius', 'speed', 'color'];
+    const params = ['radius', 'speed', 'color', 'gradient', 'fringe'];
     const bandLabels = { bass: 'Bass', mid: 'Mid', treble: 'Treble' };
 
     for (const band of bands) {
@@ -42,11 +42,11 @@ function setupAdvancedControls(container) {
 
         for (const param of params) {
             const cell = createDiv('').parent(row)
-                .style('width', '70px')
+                .style('width', '60px')
                 .style('text-align', 'center');
 
             const slider = createSlider(0, 1, AppSettings.routing[param][band], 0.1).parent(cell)
-                .style('width', '60px')
+                .style('width', '50px')
                 .style('accent-color', '#888');
 
             // Capture current param/band in closure

--- a/ui/ballControls.js
+++ b/ui/ballControls.js
@@ -1,6 +1,5 @@
 let ballCountSlider, ballCountLabel;
 let speedSlider, speedLabel;
-let mergeToggle;
 
 function setupBallControls(container) {
     // Ball count
@@ -39,23 +38,6 @@ function setupBallControls(container) {
         .style('text-align', 'center');
     speedLockPin = createLockPin(speedControls, 'speed');
 
-    // Meta mode
-    const mergeWrap = createDiv('').parent(container)
-        .style('display', 'flex')
-        .style('justify-content', 'space-between')
-        .style('align-items', 'center')
-        .style('margin-bottom', '20px');
-    createSpan('Meta Mode').parent(mergeWrap);
-    const mergeRight = createDiv('').parent(mergeWrap)
-        .style('display', 'flex')
-        .style('align-items', 'center')
-        .style('gap', '4px');
-    mergeToggle = createCheckbox('', USE_METAMERGE).parent(mergeRight)
-        .style('width', '18px')
-        .style('height', '18px')
-        .style('cursor', 'pointer');
-    metaModeLockPin = createLockPin(mergeRight, 'metaMode');
-
     // Clean display (hide title/instructions)
     const cleanWrap = createDiv('').parent(container)
         .style('display', 'flex')
@@ -75,8 +57,6 @@ function setupBallControls(container) {
     // Register UI sync so applySettings() can update controls
     registerUISync('ballCount', (val) => { ballCountSlider.value(val); ballCountLabel.html(val); });
     registerUISync('speed', (val) => { speedSlider.value(val); speedLabel.html(val); });
-    registerUISync('metaMode', (val) => { mergeToggle.checked(val); });
-
     // Set up event handlers
     ballCountSlider.input(() => {
         setBallCount(ballCountSlider.value());
@@ -92,13 +72,6 @@ function setupBallControls(container) {
         if (themeSetParams.has('speed')) {
             lockParam('speed');
             updateLockPinUI(speedLockPin, 'speed');
-        }
-    });
-    mergeToggle.changed(() => {
-        USE_METAMERGE = mergeToggle.checked();
-        if (themeSetParams.has('metaMode')) {
-            lockParam('metaMode');
-            updateLockPinUI(metaModeLockPin, 'metaMode');
         }
     });
 }

--- a/ui/colorControls.js
+++ b/ui/colorControls.js
@@ -18,7 +18,7 @@ function setupColorControls(container) {
         .style('display', 'flex')
         .style('align-items', 'center')
         .style('gap', '4px');
-    basePicker = createColorPicker('#000000').parent(baseRight)
+    basePicker = createColorPicker('#050212').parent(baseRight)
         .style('width', '40px')
         .style('height', '28px')
         .style('border', 'none')
@@ -37,7 +37,7 @@ function setupColorControls(container) {
         .style('display', 'flex')
         .style('align-items', 'center')
         .style('gap', '4px');
-    peakPicker = createColorPicker('#FFFFFF').parent(peakRight)
+    peakPicker = createColorPicker('#DCF0FF').parent(peakRight)
         .style('width', '40px')
         .style('height', '28px')
         .style('border', 'none')

--- a/ui/debugOverlay.js
+++ b/ui/debugOverlay.js
@@ -48,7 +48,7 @@ function drawDebugOverlay() {
 
     // Ball count
     fill(180, 220, 255);
-    text(`Balls: ${balls.length}  |  Meta: ${USE_METAMERGE ? 'ON' : 'OFF'}`, xPos, yPos);
+    text(`Balls: ${balls.length}  |  Fringe: ${(AppSettings.fringeIntensity * 100).toFixed(0)}%`, xPos, yPos);
     yPos += lineH;
 
     // Current speed (from first ball's base velocity)

--- a/ui/debugOverlay.js
+++ b/ui/debugOverlay.js
@@ -48,7 +48,7 @@ function drawDebugOverlay() {
 
     // Ball count
     fill(180, 220, 255);
-    text(`Balls: ${balls.length}  |  Fringe: ${(AppSettings.fringeIntensity * 100).toFixed(0)}%`, xPos, yPos);
+    text(`Balls: ${balls.length}`, xPos, yPos);
     yPos += lineH;
 
     // Current speed (from first ball's base velocity)

--- a/ui/gradientControls.js
+++ b/ui/gradientControls.js
@@ -1,0 +1,162 @@
+// Gradient palette and fringe controls
+let _paletteContainer = null;
+let _fringeSlider = null;
+
+function setupGradientControls(container) {
+    // ── Fringe Intensity ─────────────────────────────────────────────────
+    createDiv('Fringe Intensity').parent(container)
+        .style('color', '#ccc')
+        .style('margin-bottom', '6px');
+
+    const fringeRow = createDiv('').parent(container)
+        .style('display', 'flex')
+        .style('align-items', 'center')
+        .style('margin-bottom', '12px');
+
+    _fringeSlider = createSlider(0, 1, AppSettings.fringeIntensity, 0.05).parent(fringeRow)
+        .style('width', '160px')
+        .style('accent-color', '#888');
+
+    const fringeLabel = createDiv(String(AppSettings.fringeIntensity)).parent(fringeRow)
+        .style('width', '40px')
+        .style('text-align', 'right')
+        .style('color', '#999')
+        .style('font-size', '11px')
+        .style('margin-left', '8px');
+
+    _fringeSlider.input(function() {
+        const v = parseFloat(this.value());
+        fringeLabel.html(v.toFixed(2));
+        AppSettings.fringeIntensity = v;
+    });
+
+    // ── Palette Stops ────────────────────────────────────────────────────
+    createDiv('Gradient Palette').parent(container)
+        .style('color', '#ccc')
+        .style('margin-top', '8px')
+        .style('margin-bottom', '6px');
+
+    _paletteContainer = createDiv('').parent(container);
+
+    _renderPaletteStops();
+
+    // Add stop button
+    const addBtn = createButton('+ Add Stop').parent(container)
+        .style('background', 'rgba(255,255,255,0.1)')
+        .style('color', '#ccc')
+        .style('border', '1px solid rgba(255,255,255,0.2)')
+        .style('border-radius', '4px')
+        .style('padding', '4px 10px')
+        .style('cursor', 'pointer')
+        .style('font-size', '11px')
+        .style('margin-top', '6px');
+
+    addBtn.mousePressed(function() {
+        const palette = AppSettings.palette;
+        if (palette.length >= 8) return;
+        // Add a stop at the midpoint of the last two stops
+        const lastPos = palette[palette.length - 1].position;
+        const prevPos = palette.length >= 2 ? palette[palette.length - 2].position : 0;
+        const newPos = (prevPos + lastPos) / 2;
+        palette.splice(palette.length - 1, 0, {
+            position: Math.round(newPos * 100) / 100,
+            color: [128, 128, 128]
+        });
+        _onPaletteChanged();
+        _renderPaletteStops();
+    });
+
+    // Register UI sync for applySettings()
+    registerUISync('fringeIntensity', function(val) {
+        _fringeSlider.value(val);
+        fringeLabel.html(val.toFixed(2));
+    });
+    registerUISync('palette', function() {
+        _renderPaletteStops();
+    });
+}
+
+function _renderPaletteStops() {
+    // Clear existing stop rows
+    _paletteContainer.html('');
+
+    const palette = AppSettings.palette;
+
+    for (let i = 0; i < palette.length; i++) {
+        const stop = palette[i];
+        const row = createDiv('').parent(_paletteContainer)
+            .style('display', 'flex')
+            .style('align-items', 'center')
+            .style('gap', '6px')
+            .style('margin-bottom', '4px');
+
+        // Color picker
+        const picker = createColorPicker(_rgbToHex(stop.color)).parent(row)
+            .style('width', '32px')
+            .style('height', '24px')
+            .style('border', 'none')
+            .style('border-radius', '3px')
+            .style('cursor', 'pointer');
+
+        // Position slider (0.00 - 1.00)
+        const posSlider = createSlider(0, 1, stop.position, 0.01).parent(row)
+            .style('width', '80px')
+            .style('accent-color', '#888');
+
+        const posLabel = createDiv(stop.position.toFixed(2)).parent(row)
+            .style('width', '30px')
+            .style('color', '#999')
+            .style('font-size', '10px');
+
+        // Remove button (only if more than 2 stops)
+        if (palette.length > 2) {
+            const removeBtn = createButton('x').parent(row)
+                .style('background', 'none')
+                .style('color', '#666')
+                .style('border', 'none')
+                .style('cursor', 'pointer')
+                .style('font-size', '11px')
+                .style('padding', '2px 4px');
+
+            (function(idx) {
+                removeBtn.mousePressed(function() {
+                    AppSettings.palette.splice(idx, 1);
+                    _onPaletteChanged();
+                    _renderPaletteStops();
+                });
+            })(i);
+        }
+
+        // Wire up events
+        (function(idx, pk, sl, pl) {
+            pk.input(function() {
+                const c = color(pk.value());
+                AppSettings.palette[idx].color = [red(c), green(c), blue(c)];
+                _onPaletteChanged();
+            });
+            sl.input(function() {
+                const v = parseFloat(this.value());
+                AppSettings.palette[idx].position = v;
+                pl.html(v.toFixed(2));
+                _onPaletteChanged();
+            });
+        })(i, picker, posSlider, posLabel);
+    }
+}
+
+function _onPaletteChanged() {
+    // Sort by position
+    AppSettings.palette.sort(function(a, b) { return a.position - b.position; });
+    // Sync base/peak colors
+    const p = AppSettings.palette;
+    if (p.length >= 2) {
+        AppSettings.baseColor = p[0].color.slice();
+        AppSettings.peakColor = p[p.length - 1].color.slice();
+        if (typeof BASE_COLOR !== 'undefined') BASE_COLOR = p[0].color.slice();
+        if (typeof PEAK_COLOR !== 'undefined') PEAK_COLOR = p[p.length - 1].color.slice();
+        // Sync color pickers
+        _syncUI('baseColor', p[0].color);
+        _syncUI('peakColor', p[p.length - 1].color);
+    }
+    rebuildGradientLUT();
+}

--- a/ui/gradientControls.js
+++ b/ui/gradientControls.js
@@ -1,39 +1,10 @@
-// Gradient palette and fringe controls
+// Gradient palette controls
 let _paletteContainer = null;
-let _fringeSlider = null;
 
 function setupGradientControls(container) {
-    // ── Fringe Intensity ─────────────────────────────────────────────────
-    createDiv('Fringe Intensity').parent(container)
-        .style('color', '#ccc')
-        .style('margin-bottom', '6px');
-
-    const fringeRow = createDiv('').parent(container)
-        .style('display', 'flex')
-        .style('align-items', 'center')
-        .style('margin-bottom', '12px');
-
-    _fringeSlider = createSlider(0, 1, AppSettings.fringeIntensity, 0.05).parent(fringeRow)
-        .style('width', '160px')
-        .style('accent-color', '#888');
-
-    const fringeLabel = createDiv(String(AppSettings.fringeIntensity)).parent(fringeRow)
-        .style('width', '40px')
-        .style('text-align', 'right')
-        .style('color', '#999')
-        .style('font-size', '11px')
-        .style('margin-left', '8px');
-
-    _fringeSlider.input(function() {
-        const v = parseFloat(this.value());
-        fringeLabel.html(v.toFixed(2));
-        AppSettings.fringeIntensity = v;
-    });
-
     // ── Palette Stops ────────────────────────────────────────────────────
     createDiv('Gradient Palette').parent(container)
         .style('color', '#ccc')
-        .style('margin-top', '8px')
         .style('margin-bottom', '6px');
 
     _paletteContainer = createDiv('').parent(container);
@@ -67,10 +38,6 @@ function setupGradientControls(container) {
     });
 
     // Register UI sync for applySettings()
-    registerUISync('fringeIntensity', function(val) {
-        _fringeSlider.value(val);
-        fringeLabel.html(val.toFixed(2));
-    });
     registerUISync('palette', function() {
         _renderPaletteStops();
     });

--- a/ui/index.js
+++ b/ui/index.js
@@ -3,7 +3,7 @@ let uiVisible = false;
 
 // Lock pin references for auto-lock UI updates
 let baseColorLockPin, peakColorLockPin, bgColorLockPin;
-let ballCountLockPin, speedLockPin, metaModeLockPin;
+let ballCountLockPin, speedLockPin;
 
 function createCollapsibleSection(parent, title, defaultExpanded) {
     const section = createDiv('').parent(parent).style('margin-bottom', '16px');

--- a/ui/index.js
+++ b/ui/index.js
@@ -123,6 +123,9 @@ function setupUI() {
     const colorSection = createCollapsibleSection(uiContainer, 'Colors', true);
     setupColorControls(colorSection);
 
+    const gradientSection = createCollapsibleSection(uiContainer, 'Gradient', true);
+    setupGradientControls(gradientSection);
+
     const ballSection = createCollapsibleSection(uiContainer, 'Ball Settings', false);
     setupBallControls(ballSection);
 


### PR DESCRIPTION
update metaball with holographic gradient display

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Replaces the core metaball rendering path with a per-frame pixel-buffer gradient renderer and new settings/UI plumbing, which could affect performance and visual correctness across devices/resizes. Changes are localized to the visualizer pipeline (no auth/data concerns) but touch multiple integration points (settings, theme, UI, scripts).
> 
> **Overview**
> **Replaces the metaball visuals**: removes the marching-squares/solid-blob (and per-ball circle) rendering and instead renders a continuous scalar-field **gradient** into a low-res pixel buffer (`drawGradientField()`), upscaled with smoothing and optionally modulated by audio-reactive **interference fringes**.
> 
> **Adds multi-stop palette + fringe settings**: introduces `AppSettings.palette` (2–8 stops) and `fringeIntensity`, generates a 256-entry HSL-interpolated LUT (`displays/gradientLUT.js`), and keeps `baseColor`/`peakColor` in sync with the first/last palette stops.
> 
> **Updates theme + UI wiring**: extends routing with `gradient`/`fringe` targets (UI matrix updated), removes the `Meta Mode` toggle from ball controls (deprecated), adds a new Gradient UI section for palette editing and fringe intensity, updates defaults/colors, and fixes `spectrumDisplay` colorMode leakage via `push()`/`pop()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c250b7a76b2b6d4787d9162f222f039936bff0ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->